### PR TITLE
Linkcast - A chrome ext. built with Hyperapp

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 - [hyperapp-todo](https://github.com/marcusasplund/hyperapp-todo-simple) - Simple CRUD todo-app with Hyperapp.
 - [hyperapp-wiki](https://github.com/lukejacksonn/hyperapp-wiki) - Example of how Hyperapp could be used to serve its own wiki with gh-pages.
 - [hypernews](https://github.com/traducer/hypernews) - Hacker News clone with Hyperapp.
-- [linkcast](https://github.com/ajaxtown/linkcast) - A chrome extensions to share links socialize in realtime
+- [linkcast](https://github.com/ajaxtown/linkcast) - A chrome extensions built with Hyperapp to share links in groups and socialize with offline capability.
 
 ## Utilities
 - [hyperapp-dot-notation-reducer](https://github.com/alber70g/hyperapp-dot-notation-reducer) - Allows actions to return an object with a path as a property in order to edit deeply nested state.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 - [hyperapp-todo](https://github.com/marcusasplund/hyperapp-todo-simple) - Simple CRUD todo-app with Hyperapp.
 - [hyperapp-wiki](https://github.com/lukejacksonn/hyperapp-wiki) - Example of how Hyperapp could be used to serve its own wiki with gh-pages.
 - [hypernews](https://github.com/traducer/hypernews) - Hacker News clone with Hyperapp.
+- [linkcast](https://github.com/ajaxtown/linkcast) - A chrome extensions to share links socialize in realtime
 
 ## Utilities
 - [hyperapp-dot-notation-reducer](https://github.com/alber70g/hyperapp-dot-notation-reducer) - Allows actions to return an object with a path as a property in order to edit deeply nested state.


### PR DESCRIPTION
Linkcast is a chrome extension built with HyperApp.
> Linkcast is a chrome extension which organises your links and facilitates sharing. It allows you to create groups (public/private) and post relevant links in relevant groups. Other users can collaborate by joining those groups depending on the type of the group and the permission.

This is the first chrome extension built with Linkcast. Please review.